### PR TITLE
Komalistの更新

### DIFF
--- a/KomaList.pde
+++ b/KomaList.pde
@@ -18,4 +18,22 @@ class KomaList {
       k.draw();
     }
   }
+  AbstractKoma getSelectedKoma() {
+    for (AbstractKoma k : komaArray) {
+      if (k.kStat.selected) return k;
+    }
+    return null;
+  }
+
+  void select(int x, int y) {
+    AbstractKoma koma = this.getKomaFromPlaceByTeam(x, y, gs.turn);
+    if (koma != null) koma.kStat.selected=true;
+  }
+
+  AbstractKoma getKomaFromPlaceByTeam(int x, int y, int team) {
+    for (AbstractKoma k : this.komaArray) {
+      if (team==k.team && x == k.x && y == k.y && k.kStat.active) return k;
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
「AbstractKoma koma = this.getKomaFromPlaceByTeam(x, y, gs.turn);」のコンパイルエラーはTask3-5が完了しなければ取れない（GameStatusの宣言をDoubutsu.pdeで行っているため）ようです。（Task3-3参照）
なので、KomaListクラスに各メソッドが追加されているか確認出来たらマージして下さい。